### PR TITLE
inscreen: add missing methods

### DIFF
--- a/biometrics/fingerprint/inscreen/1.1/IFingerprintInscreen.hal
+++ b/biometrics/fingerprint/inscreen/1.1/IFingerprintInscreen.hal
@@ -19,6 +19,8 @@ package vendor.lineage.biometrics.fingerprint.inscreen@1.1;
 import vendor.lineage.biometrics.fingerprint.inscreen@1.0;
 
 interface IFingerprintInscreen extends vendor.lineage.biometrics.fingerprint.inscreen@1.0::IFingerprintInscreen{
-
+    getHbmOffDelay() generates (int32_t delayOff);
+    getHbmOnDelay() generates (int32_t delayOn);
+    supportsAlwaysOnHBM() generates (bool status);
     switchHbm(bool enabled);
 };


### PR DESCRIPTION
Nuked when bumped to 1.1 but actually those method allow device hal to work on multiple devices with configuration in dt hal impl.
Note: also in fwb fodcircleview it needs to add methods as of now Hbm on and off delay are fixed, instead every device may be able to set it in device tree